### PR TITLE
Notebook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urbit-http-api"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Robert Kornacki <11645932+robkorn@users.noreply.github.com>"]
 edition = "2018"
 description = "Wraps the Urbit ship http api exposing it as an easy-to-use Rust crate."

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -64,7 +64,9 @@ impl Channel {
             let mut headers = HeaderMap::new();
             headers.append("cookie", ship_interface.session_auth.clone());
             // Create the receiver
-            let receiver = EventSource::new(Url::parse(&channel_url).unwrap(), headers);
+            let url_structured =
+                Url::parse(&channel_url).map_err(|_| UrbitAPIError::FailedToCreateNewChannel)?;
+            let receiver = EventSource::new(url_structured, headers);
 
             return Ok(Channel {
                 ship_interface: ship_interface,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -22,7 +22,7 @@ pub struct AuthoredMessage {
     pub author: String,
     pub contents: Message,
     pub time_sent: String,
-    pub index: String
+    pub index: String,
 }
 
 impl AuthoredMessage {
@@ -32,13 +32,17 @@ impl AuthoredMessage {
             author: author.to_string(),
             contents: contents.clone(),
             time_sent: time_sent.to_string(),
-            index: index.to_string()
+            index: index.to_string(),
         }
     }
-    
     /// Parses a `Node` into `Self`
     pub fn from_node(node: &Node) -> Self {
-        Self::new(&node.author, &node.contents, &node.time_sent_formatted(), &node.index)
+        Self::new(
+            &node.author,
+            &node.contents,
+            &node.time_sent_formatted(),
+            &node.index,
+        )
     }
 
     /// Converts self into a human readable formatted string which

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -16,27 +16,29 @@ pub struct Chat<'a> {
 /// It is technically an alias for the `NodeContents` struct.
 pub type Message = NodeContents;
 
-/// A `Message` with the author @p, and post time also included
+/// A `Message` with the author @p, post time and index also included
 #[derive(Clone, Debug)]
 pub struct AuthoredMessage {
     pub author: String,
     pub contents: Message,
     pub time_sent: String,
+    pub index: String
 }
 
 impl AuthoredMessage {
     /// Create a new `AuthoredMessage`
-    pub fn new(author: &str, contents: &Message, time_sent: &str) -> Self {
+    pub fn new(author: &str, contents: &Message, time_sent: &str, index: &str) -> Self {
         AuthoredMessage {
             author: author.to_string(),
             contents: contents.clone(),
             time_sent: time_sent.to_string(),
+            index: index.to_string()
         }
     }
-
+    
     /// Parses a `Node` into `Self`
     pub fn from_node(node: &Node) -> Self {
-        Self::new(&node.author, &node.contents, &node.time_sent_formatted())
+        Self::new(&node.author, &node.contents, &node.time_sent_formatted(), &node.index)
     }
 
     /// Converts self into a human readable formatted string which
@@ -160,7 +162,7 @@ impl<'a> Chat<'a> {
                                     continue;
                                 }
                                 // Otherwise, parse json to a `Node`
-                                if let Ok(node) = Node::from_graph_update_json_childless(&json) {
+                                if let Ok(node) = Node::from_graph_update_json(&json) {
                                     // Parse it as an `AuthoredMessage`
                                     let authored_message = AuthoredMessage::from_node(&node);
                                     let _ = s.send(authored_message);

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum UrbitAPIError {
     FailedToSendChatMessage(String),
     #[error("Failed to acquire graph from Graph Store for resource {0}.")]
     FailedToGetGraph(String),
+    #[error("Failed to acquire graph node from Graph Store for resource + index {0}.")]
+    FailedToGetGraphNode(String),
     #[error("Failed to archive graph from Graph Store for resource {0}.")]
     FailedToArchiveGraph(String),
     #[error("Failed to add nodes to Graph Store for resource {0}.")]
@@ -31,6 +33,14 @@ pub enum UrbitAPIError {
     FailedToInsertGraphNode,
     #[error("The following graph node is not a valid Notebook Note node {0}")]
     InvalidNoteGraphNode(String),
+    #[error("The following graph node index is not a valid Notebook Note node index {0}")]
+    InvalidNoteGraphNodeIndex(String),
+    #[error("Failed to create a Notebook Note from these nodes {0}")]
+    FailedToCreateNote(String),
+    #[error("Failed to create a Notebook Comment from these nodes {0}")]
+    FailedToCreateComment(String),
+    #[error("The following graph node index is not a valid Notebook Comment node index {0}")]
+    InvalidCommentGraphNodeIndex(String),
     #[error("{0}")]
     Other(String),
     #[error(transparent)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -212,7 +212,6 @@ impl Node {
     /// Converts to `JsonValue`
     /// json representation of a node
     fn to_json_value(&self) -> JsonValue {
-        
         let mut children = object!();
         for child in &self.children {
             children[child.index_tail()] = child.to_json_value();
@@ -287,7 +286,6 @@ impl Node {
             children: vec![],
         })
     }
-    
     /// Convert from node `JsonValue` which is wrapped up in a few wrapper fields
     /// into a `Node`, with children if they exist.
     pub fn from_graph_update_json(wrapped_json: &JsonValue) -> Result<Node> {
@@ -351,10 +349,9 @@ impl Node {
         }
 
         // children
-        let mut node_children : Vec<Node> = vec![];
-        
+        let mut node_children: Vec<Node> = vec![];
         if let JsonValue::Object(o) = children {
-            for (_,val) in o.iter() {
+            for (_, val) in o.iter() {
                 if let Ok(child_node) = Node::from_json(val) {
                     node_children.push(child_node);
                 }
@@ -371,8 +368,6 @@ impl Node {
             children: node_children,
         })
     }
-
-    
 }
 
 /// Methods for `NodeContents`

--- a/src/graphstore.rs
+++ b/src/graphstore.rs
@@ -1,5 +1,5 @@
 use crate::graph::{Graph, Node, NodeContents};
-use crate::helper::{get_current_da_time,get_current_time,index_dec_to_ud};
+use crate::helper::{get_current_da_time, get_current_time, index_dec_to_ud};
 use crate::{Channel, Result, UrbitAPIError};
 use json::object;
 
@@ -14,7 +14,6 @@ impl<'a> GraphStore<'a> {
     pub fn new_node(&self, contents: &NodeContents) -> Node {
         // Add the ~ to the ship name to be used within the post as author
         let ship = format!("~{}", self.channel.ship_interface.ship_name);
-        
         // The index. For chat the default is current `@da` time as atom encoding with a `/` in front.
         let index = format!("/{}", get_current_da_time());
 
@@ -32,10 +31,14 @@ impl<'a> GraphStore<'a> {
     }
 
     /// Create a new Graph Store node using a specified index and creation time, and connected ship as author
-    pub fn new_node_with_index(&self, node_index: &str, unix_time: u64, contents: &NodeContents) -> Node {
+    pub fn new_node_with_index(
+        &self,
+        node_index: &str,
+        unix_time: u64,
+        contents: &NodeContents,
+    ) -> Node {
         // Add the ~ to the ship name to be used within the post as author
         let ship = format!("~{}", self.channel.ship_interface.ship_name);
-        
         Node::new(
             node_index.to_string(),
             ship.clone(),
@@ -112,16 +115,19 @@ impl<'a> GraphStore<'a> {
 
         if res.status().as_u16() == 200 {
             if let Ok(body) = res.text() {
-                
                 let graph_json = json::parse(&body).expect("Failed to parse graph json.");
                 return Graph::from_json(graph_json);
             }
         }
         return Err(UrbitAPIError::FailedToGetGraph(resource_name.to_string()));
     }
-    
     /// Acquire a node from Graph Store
-    pub fn get_node(&mut self, resource_ship: &str, resource_name: &str, node_index: &str) -> Result<Node> {
+    pub fn get_node(
+        &mut self,
+        resource_ship: &str,
+        resource_name: &str,
+        node_index: &str,
+    ) -> Result<Node> {
         let path_nodes = index_dec_to_ud(node_index);
         let path = format!("/node/{}/{}{}", resource_ship, resource_name, &path_nodes);
         let res = self
@@ -130,14 +136,16 @@ impl<'a> GraphStore<'a> {
             .scry("graph-store", &path, "json")?;
 
         if res.status().as_u16() == 200 {
-            if let Ok(body) = res.text() {                
+            if let Ok(body) = res.text() {
                 let graph_json = json::parse(&body).expect("Failed to parse graph node json.");
                 return Node::from_graph_update_json(&graph_json);
             }
         }
-        return Err(UrbitAPIError::FailedToGetGraphNode(format!("/{}/{}/{}",resource_ship,resource_name, node_index)));
+        return Err(UrbitAPIError::FailedToGetGraphNode(format!(
+            "/{}/{}/{}",
+            resource_ship, resource_name, node_index
+        )));
     }
-    
     /// Archive a graph in Graph Store
     pub fn archive_graph(&mut self, resource_ship: &str, resource_name: &str) -> Result<String> {
         let path = format!("/archive/{}/{}", resource_ship, resource_name);
@@ -176,5 +184,5 @@ impl<'a> GraphStore<'a> {
                 resource_name.to_string(),
             ));
         }
-    }    
+    }
 }

--- a/src/graphstore.rs
+++ b/src/graphstore.rs
@@ -1,8 +1,7 @@
 use crate::graph::{Graph, Node, NodeContents};
-use crate::helper::get_current_da_time;
+use crate::helper::{get_current_da_time,get_current_time,index_dec_to_ud};
 use crate::{Channel, Result, UrbitAPIError};
 use json::object;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// A struct which exposes Graph Store functionality
 pub struct GraphStore<'a> {
@@ -15,18 +14,30 @@ impl<'a> GraphStore<'a> {
     pub fn new_node(&self, contents: &NodeContents) -> Node {
         // Add the ~ to the ship name to be used within the post as author
         let ship = format!("~{}", self.channel.ship_interface.ship_name);
-
+        
         // The index. For chat the default is current `@da` time as atom encoding with a `/` in front.
         let index = format!("/{}", get_current_da_time());
 
         // Get the current Unix Time
-        let unix_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64;
+        let unix_time = get_current_time();
 
         Node::new(
             index,
+            ship.clone(),
+            unix_time,
+            vec![],
+            contents.clone(),
+            None,
+        )
+    }
+
+    /// Create a new Graph Store node using a specified index and creation time, and connected ship as author
+    pub fn new_node_with_index(&self, node_index: &str, unix_time: u64, contents: &NodeContents) -> Node {
+        // Add the ~ to the ship name to be used within the post as author
+        let ship = format!("~{}", self.channel.ship_interface.ship_name);
+        
+        Node::new(
+            node_index.to_string(),
             ship.clone(),
             unix_time,
             vec![],
@@ -101,13 +112,32 @@ impl<'a> GraphStore<'a> {
 
         if res.status().as_u16() == 200 {
             if let Ok(body) = res.text() {
+                
                 let graph_json = json::parse(&body).expect("Failed to parse graph json.");
                 return Graph::from_json(graph_json);
             }
         }
         return Err(UrbitAPIError::FailedToGetGraph(resource_name.to_string()));
     }
+    
+    /// Acquire a node from Graph Store
+    pub fn get_node(&mut self, resource_ship: &str, resource_name: &str, node_index: &str) -> Result<Node> {
+        let path_nodes = index_dec_to_ud(node_index);
+        let path = format!("/node/{}/{}{}", resource_ship, resource_name, &path_nodes);
+        let res = self
+            .channel
+            .ship_interface
+            .scry("graph-store", &path, "json")?;
 
+        if res.status().as_u16() == 200 {
+            if let Ok(body) = res.text() {                
+                let graph_json = json::parse(&body).expect("Failed to parse graph node json.");
+                return Node::from_graph_update_json(&graph_json);
+            }
+        }
+        return Err(UrbitAPIError::FailedToGetGraphNode(format!("/{}/{}/{}",resource_ship,resource_name, node_index)));
+    }
+    
     /// Archive a graph in Graph Store
     pub fn archive_graph(&mut self, resource_ship: &str, resource_name: &str) -> Result<String> {
         let path = format!("/archive/{}/{}", resource_ship, resource_name);
@@ -146,5 +176,5 @@ impl<'a> GraphStore<'a> {
                 resource_name.to_string(),
             ));
         }
-    }
+    }    
 }

--- a/src/graphstore.rs
+++ b/src/graphstore.rs
@@ -31,7 +31,7 @@ impl<'a> GraphStore<'a> {
     }
 
     /// Create a new Graph Store node using a specified index and creation time, and connected ship as author
-    pub fn new_node_with_index(
+    pub fn new_node_specified(
         &self,
         node_index: &str,
         unix_time: u64,

--- a/src/graphstore.rs
+++ b/src/graphstore.rs
@@ -113,14 +113,18 @@ impl<'a> GraphStore<'a> {
             .ship_interface
             .scry("graph-store", &path, "json")?;
 
+        // If successfully acquired graph json
         if res.status().as_u16() == 200 {
             if let Ok(body) = res.text() {
-                let graph_json = json::parse(&body).expect("Failed to parse graph json.");
-                return Graph::from_json(graph_json);
+                if let Ok(graph_json) = json::parse(&body) {
+                    return Graph::from_json(graph_json);
+                }
             }
         }
-        return Err(UrbitAPIError::FailedToGetGraph(resource_name.to_string()));
+        // Else return error
+        Err(UrbitAPIError::FailedToGetGraph(resource_name.to_string()))
     }
+
     /// Acquire a node from Graph Store
     pub fn get_node(
         &mut self,
@@ -135,17 +139,21 @@ impl<'a> GraphStore<'a> {
             .ship_interface
             .scry("graph-store", &path, "json")?;
 
+        // If successfully acquired node json
         if res.status().as_u16() == 200 {
             if let Ok(body) = res.text() {
-                let graph_json = json::parse(&body).expect("Failed to parse graph node json.");
-                return Node::from_graph_update_json(&graph_json);
+                if let Ok(node_json) = json::parse(&body) {
+                    return Node::from_graph_update_json(&node_json);
+                }
             }
         }
-        return Err(UrbitAPIError::FailedToGetGraphNode(format!(
+        // Else return error
+        Err(UrbitAPIError::FailedToGetGraphNode(format!(
             "/{}/{}/{}",
             resource_ship, resource_name, node_index
-        )));
+        )))
     }
+
     /// Archive a graph in Graph Store
     pub fn archive_graph(&mut self, resource_ship: &str, resource_name: &str) -> Result<String> {
         let path = format!("/archive/{}/{}", resource_ship, resource_name);

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -11,11 +11,42 @@ pub fn unix_time_to_da(unix_time: u64) -> u128 {
     DA_UNIX_EPOCH + time_since_epoch
 }
 
-// Acquire the current time in Urbit `@da` encoding
-pub fn get_current_da_time() -> u128 {
-    let unix_time = SystemTime::now()
+// Acquire the current time as u64
+pub fn get_current_time() -> u64 {
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_millis() as u64;
+        .as_millis() as u64
+}
+
+// Acquire the current time in Urbit `@da` encoding
+pub fn get_current_da_time() -> u128 {
+    let unix_time = get_current_time();
     unix_time_to_da(unix_time)
+}
+
+/// encode an index path into urbit ud format
+/// /12345678901234/1/10987654321 -> /12.345.678.901.234/1/10.987.654.321
+pub fn index_dec_to_ud(index: &str) -> String {
+    //split the index
+    let index_split : Vec<&str> = index.split("/").collect();
+    let mut udindex = String::new();
+    //handle each segment
+    for i in 0..index_split.len() {
+        if index_split[i].len() > 0 {
+            let mut rev : String = index_split[i].chars().rev().collect();
+            let mut out = String::new();
+            while rev.len() >= 3 {
+                let chunk : String = rev.drain(..3).collect();
+                out += &chunk;
+                if rev.len() > 0 {
+                    out += ".";
+                }
+            }
+            out += &rev;
+            let seg : String = out.chars().rev().collect();
+            udindex += &format!("/{}", &seg);
+        }        
+    }
+    udindex
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -29,24 +29,24 @@ pub fn get_current_da_time() -> u128 {
 /// /12345678901234/1/10987654321 -> /12.345.678.901.234/1/10.987.654.321
 pub fn index_dec_to_ud(index: &str) -> String {
     //split the index
-    let index_split : Vec<&str> = index.split("/").collect();
+    let index_split: Vec<&str> = index.split("/").collect();
     let mut udindex = String::new();
     //handle each segment
     for i in 0..index_split.len() {
         if index_split[i].len() > 0 {
-            let mut rev : String = index_split[i].chars().rev().collect();
+            let mut rev: String = index_split[i].chars().rev().collect();
             let mut out = String::new();
             while rev.len() >= 3 {
-                let chunk : String = rev.drain(..3).collect();
+                let chunk: String = rev.drain(..3).collect();
                 out += &chunk;
                 if rev.len() > 0 {
                     out += ".";
                 }
             }
             out += &rev;
-            let seg : String = out.chars().rev().collect();
+            let seg: String = out.chars().rev().collect();
             udindex += &format!("/{}", &seg);
-        }        
+        }
     }
     udindex
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -5,13 +5,13 @@ static DA_UNIX_EPOCH: u128 = 170141184475152167957503069145530368000;
 // `@ud` ~s1
 static DA_SECOND: u128 = 18446744073709551616;
 
-// Convert from Unix time in milliseconds to Urbit `@da` time
+/// Convert from Unix time in milliseconds to Urbit `@da` time
 pub fn unix_time_to_da(unix_time: u64) -> u128 {
     let time_since_epoch = (unix_time as u128 * DA_SECOND) / 1000;
     DA_UNIX_EPOCH + time_since_epoch
 }
 
-// Acquire the current time as u64
+/// Acquire the current time as u64
 pub fn get_current_time() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -19,19 +19,19 @@ pub fn get_current_time() -> u64 {
         .as_millis() as u64
 }
 
-// Acquire the current time in Urbit `@da` encoding
+/// Acquire the current time in Urbit `@da` encoding
 pub fn get_current_da_time() -> u128 {
     let unix_time = get_current_time();
     unix_time_to_da(unix_time)
 }
 
-/// encode an index path into urbit ud format
+/// Encode an index path into urbit ud format
 /// /12345678901234/1/10987654321 -> /12.345.678.901.234/1/10.987.654.321
 pub fn index_dec_to_ud(index: &str) -> String {
-    //split the index
+    // Split the index
     let index_split: Vec<&str> = index.split("/").collect();
     let mut udindex = String::new();
-    //handle each segment
+    // Handle each segment
     for i in 0..index_split.len() {
         if index_split[i].len() > 0 {
             let mut rev: String = index_split[i].chars().rev().collect();

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -48,7 +48,8 @@ impl ShipInterface {
             .map_err(|_| UrbitAPIError::FailedToLogin)?;
 
         // Trim the auth string to acquire the ship name
-        let ship_name = &auth_string[9..auth_string.find('=').unwrap()];
+        let end_pos = auth_string.find('=').ok_or(UrbitAPIError::FailedToLogin)?;
+        let ship_name = &auth_string[9..end_pos];
 
         Ok(ShipInterface {
             url: ship_url.to_string(),

--- a/src/local_config.rs
+++ b/src/local_config.rs
@@ -46,7 +46,7 @@ pub fn ship_interface_from_local_config() -> Option<ShipInterface> {
 /// data inside to create a `ShipInterface`
 pub fn ship_interface_from_config(path_to_file: &str) -> Option<ShipInterface> {
     let yaml_str = std::fs::read_to_string(path_to_file).ok()?;
-    let yaml = YamlLoader::load_from_str(&yaml_str).unwrap()[0].clone();
+    let yaml = YamlLoader::load_from_str(&yaml_str).ok()?[0].clone();
     ship_interface_from_yaml(yaml)
 }
 

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -1,6 +1,7 @@
 use crate::comment::Comment;
 use crate::graph::NodeContents;
 use crate::{Channel, Node, Result, UrbitAPIError};
+use crate::helper::{get_current_da_time,get_current_time};
 
 /// A struct that provides an interface for interacting with Urbit notebooks
 pub struct Notebook<'a> {
@@ -13,10 +14,16 @@ pub struct Note {
     pub title: String,
     pub author: String,
     pub time_sent: String,
-    /// The contents of the latest revision of the Note
-    pub contents: NodeContents,
-    // pub old_revisions_content: Vec<NodeContents>
+    pub contents: String,
     pub comments: Vec<Comment>,
+    pub index: String  
+}
+
+/// helper struct for analysing Notebook node indices
+#[derive(Clone, Debug)]
+pub struct NotebookIndex<'a> {
+    pub index: &'a str,
+    pub index_split : Vec<&'a str>
 }
 
 impl Note {
@@ -25,20 +32,22 @@ impl Note {
         title: &str,
         author: &str,
         time_sent: &str,
-        contents: &NodeContents,
+        contents: &str,
         comments: &Vec<Comment>,
+        index: &str        
     ) -> Note {
         Note {
             title: title.to_string(),
             author: author.to_string(),
             time_sent: time_sent.to_string(),
-            contents: contents.clone(),
+            contents: contents.to_string(),
             comments: comments.clone(),
+            index: index.to_string()
         }
     }
 
     /// Convert from a `Node` to a `Note`
-    pub fn from_node(node: &Node) -> Result<Note> {
+    pub fn from_node(node: &Node, revision: Option<String>) -> Result<Note> {
         let mut comments: Vec<Comment> = vec![];
         // Find the comments node which has an index tail of `2`
         let comments_node = node
@@ -46,42 +55,61 @@ impl Note {
             .iter()
             .find(|c| c.index_tail() == "2")
             .ok_or(UrbitAPIError::InvalidNoteGraphNode(node.to_json().dump()))?;
-        // Find the note content node (which holds all revisions as children) which has an index tail of `1`
+        // Find the note content node which has an index tail of `1`
         let content_node = node
             .children
             .iter()
             .find(|c| c.index_tail() == "1")
             .ok_or(UrbitAPIError::InvalidNoteGraphNode(node.to_json().dump()))?;
 
+        // Find the latest revision of each of the notebook comments
         for comment_node in &comments_node.children {
-            for child in &comment_node.children {
-                comments.push(Comment::from_node(child));
+            let mut latest_comment_revision_node = comment_node.children[0].clone();
+            for revision_node in &comment_node.children {
+                if revision_node.index_tail() > latest_comment_revision_node.index_tail() {
+                    latest_comment_revision_node = revision_node.clone();
+                }
             }
+            comments.push(Comment::from_node(&latest_comment_revision_node));
         }
 
-        // Find the latest revision of the notebook content
-        let mut latest_revision_node = content_node.children[0].clone();
-        for revision_node in &content_node.children {
-            if revision_node.index_tail() > latest_revision_node.index_tail() {
-                latest_revision_node = revision_node.clone()
+        let mut fetched_revision_node = content_node.children[0].clone();
+
+        match revision {
+            Some(idx) => {
+                //find a specific revision of the notebook content
+                for revision_node in &content_node.children {
+                    if revision_node.index == idx {
+                        fetched_revision_node = revision_node.clone();
+                    }
+                }
+            }
+            None => {
+                // Find the latest revision of the notebook content
+                for revision_node in &content_node.children {
+                    if revision_node.index_tail() > fetched_revision_node.index_tail() {
+                        fetched_revision_node = revision_node.clone();
+                    }
+                }
             }
         }
+        
         // Acquire the title, which is the first item in the revision node of the note
-        let title = format!("{}", latest_revision_node.contents.content_list[0]["text"]);
-        // Recreate the revision node contents with the title removed
-        let contents =
-            NodeContents::from_json(latest_revision_node.contents.content_list[1..].to_vec());
-        let author = node.author.clone();
-        let time_sent = node.time_sent_formatted();
+        let title = format!("{}", fetched_revision_node.contents.content_list[0]["text"]);
+        // Acquire the note body, which is all in the second item in the revision node of the note
+        let contents = format!("{}", fetched_revision_node.contents.content_list[1]["text"]);
+        let author = fetched_revision_node.author.clone();
+        let time_sent = fetched_revision_node.time_sent_formatted();
+    
 
         // Create the note
-        Ok(Note::new(&title, &author, &time_sent, &contents, &comments))
-    }
+        Ok(Note::new(&title, &author, &time_sent, &contents, &comments, &fetched_revision_node.index))
+    }   
 
     /// Convert the contents of the latest revision of the Note to
     /// a series of markdown `String`s
     pub fn content_as_markdown(&self) -> Vec<String> {
-        let formatted_string = self.contents.to_formatted_string();
+        let formatted_string = self.contents.clone();
         formatted_string
             .split("\\n")
             .map(|l| l.to_string())
@@ -90,6 +118,7 @@ impl Note {
 }
 
 impl<'a> Notebook<'a> {
+
     /// Extracts a Notebook's graph from the connected ship and parses it into a vector of `Note`s
     pub fn export_notebook(
         &mut self,
@@ -104,10 +133,389 @@ impl<'a> Notebook<'a> {
         // Parse each top level node (Note) in the notebook graph
         let mut notes = vec![];
         for node in &graph.nodes {
-            let note = Note::from_node(node)?;
+            let note = Note::from_node(node, None)?;
             notes.push(note);
         }
 
         Ok(notes)
     }
+
+    /// fetch a note object given an index `note_index`
+    /// `note_index` can be any valid note index (even an index of a comment on the note)
+    ///  will fetch a specific revision if passed index of one, otherwise the latest revision
+    /// (comments fetched will always be the latest revisions)
+    pub fn fetch_note(&mut self, notebook_ship: &str, notebook_name: &str, note_index: &str) -> Result<Note> {
+        
+        //check index
+        let index = NotebookIndex::new(note_index);
+        
+        if !index.is_valid() {
+            return Err(UrbitAPIError::InvalidNoteGraphNodeIndex(note_index.to_string()));
+        }
+
+        //root note index
+        let note_root_index = index.note_root_index();
+
+        //get the note root node
+        let node = &self
+            .channel
+            .graph_store()
+            .get_node(notebook_ship, notebook_name, &note_root_index)?;
+        
+        let revision = match index.is_note_revision() {
+            true => Some(note_index.to_string()),
+            false => None
+        };
+
+        return Ok(Note::from_node(node, revision)?); 
+    }
+
+    /// find the index of the latest revision of a note given an index `note_index`
+    /// `note_index` can be any valid note index (even an index of a comment on the note)
+    pub fn fetch_note_latest_revision_index(&mut self, notebook_ship: &str, notebook_name: &str, note_index: &str) -> Result<String> {
+        
+        //check index
+        let index = NotebookIndex::new(note_index);
+        
+        if !index.is_valid() {
+            return Err(UrbitAPIError::InvalidNoteGraphNodeIndex(note_index.to_string()));
+        }
+
+        //root note index
+        let note_root_index = index.note_root_index();
+
+        //get note root node
+        let node = &self
+            .channel
+            .graph_store()
+            .get_node(notebook_ship, notebook_name, &note_root_index)?;
+       
+        for pnode in &node.children {
+            if pnode.index_tail() == "1" {
+                let mut latestindex = NotebookIndex::new(&pnode.children[0].index);
+                for rev in &pnode.children {
+                    let revindex = NotebookIndex::new(&rev.index);
+                    if revindex.index_tail() > latestindex.index_tail() {
+                        latestindex = revindex.clone();
+                    }
+                } 
+                return Ok(latestindex.index.to_string()); 
+            } 
+        }
+
+        Err(UrbitAPIError::InvalidNoteGraphNodeIndex(note_index.to_string()))
+    }
+
+    /// fetch a comment given an index `comment_index`
+    /// index can be the comment root node index, or index of any revision
+    /// will fetch most recent revision if passed root node index
+    pub fn fetch_comment(&mut self, notebook_ship: &str, notebook_name: &str, comment_index: &str) -> Result<Comment> {
+
+        //check index
+        let index = NotebookIndex::new(comment_index);
+
+        if !index.is_valid_comment_index() {
+            return Err(UrbitAPIError::InvalidCommentGraphNodeIndex(comment_index.to_string()));
+        }
+        
+        let comment_root_index = index.comment_root_index()?;
+
+        //get comment root node
+        let node = &self
+            .channel
+            .graph_store()
+            .get_node(notebook_ship, notebook_name, &comment_root_index)?;
+
+        if index.is_comment_root() {
+            //find latest comment revision
+            let mut newest = node.children[0].clone();
+            for rnode in &node.children {
+                if rnode.index_tail() > newest.index_tail() {
+                    newest = rnode.clone();
+                }
+            }
+            return Ok(Comment::from_node(&newest));
+        } else {
+            //find specific comment revision
+            for rnode in &node.children {
+                if rnode.index == comment_index {
+                    return Ok(Comment::from_node(&rnode));
+                }
+            }
+        }
+        
+
+        Err(UrbitAPIError::InvalidCommentGraphNodeIndex(comment_index.to_string()))
+    }
+
+    /// fetch index of latest revision of a comment given an index `comment_index`
+    /// index can be the comment root node index, or the index of any revision of the comment
+    pub fn fetch_comment_latest_revision_index(&mut self, notebook_ship: &str, notebook_name: &str, comment_index: &str) -> Result<String> {
+
+        //check index
+        let index = NotebookIndex::new(comment_index);
+
+        if !index.is_valid_comment_index() {
+            return Err(UrbitAPIError::InvalidCommentGraphNodeIndex(comment_index.to_string()));
+        }
+        
+        let comment_root_index = index.comment_root_index()?;
+
+        //get comment root node
+        let node = &self
+            .channel
+            .graph_store()
+            .get_node(notebook_ship, notebook_name, &comment_root_index)?;        
+
+        if node.children.len() > 0 {
+            let mut newestindex = NotebookIndex::new(&node.children[0].index);
+            for rnode in &node.children {
+                let revindex = NotebookIndex::new(&rnode.index);
+                if revindex.index_tail() > newestindex.index_tail() {
+                    newestindex = revindex.clone();
+                }
+            }
+            return Ok(newestindex.index.to_string());   
+        }                             
+        
+        Err(UrbitAPIError::InvalidCommentGraphNodeIndex(comment_index.to_string()))
+    }
+
+    /// adds a new note to the notebook
+    /// returns the index of the first revision of the created note
+    pub fn add_note(&mut self, notebook_ship: &str, notebook_name: &str, title: &str, body: &str) -> Result<String> {
+        let mut gs = self.channel.graph_store();
+        //make the root node for the note
+        let node_root = gs.new_node(&NodeContents::new());
+        //save creation time for other nodes
+        let unix_time = node_root.time_sent;
+        //index helper
+        let index = NotebookIndex::new(&node_root.index);
+        //make child 1 for note content
+        //make child 2 for comments
+        //make child 1/1 for initial note revision
+        let node_root = node_root.add_child(&gs.new_node_with_index(&index.note_content_node_index(), unix_time, &NodeContents::new()))
+                                 .add_child(&gs.new_node_with_index(&index.note_comments_node_index(), unix_time, &NodeContents::new()))        
+                                 .add_child(&gs.new_node_with_index(&index.note_revision_index(1), 
+                                            unix_time,
+                                            &NodeContents::new().add_text(title).add_text(body)));
+
+        if let Ok(_) = gs.add_node(notebook_ship, notebook_name, &node_root)
+        {
+            Ok(index.note_revision_index(1))
+        } else {
+            Err(UrbitAPIError::FailedToCreateNote(node_root.to_json().dump()))
+        }      
+    }
+
+    /// update an existing note with new title and body
+    /// note_index can be any valid note index, (even a comment index for any comment on the note)
+    /// returns index of new revision created
+    pub fn update_note(&mut self, notebook_ship: &str, notebook_name: &str, note_index: &str, title: &str, body: &str) -> Result<String> {
+        
+        //fetch latest revision of note (will return error if not a valid note index)
+        let note_latest_index = self.fetch_note_latest_revision_index(notebook_ship, notebook_name, note_index)?;
+        //index helper
+        let index = NotebookIndex::new(&note_latest_index);
+        //build new node index
+        let note_new_index = index.next_revision_index()?;
+
+        let mut gs = self.channel.graph_store();
+        let unix_time = get_current_time();
+
+        // add the node
+        let node = gs.new_node_with_index(&note_new_index, unix_time, &NodeContents::new().add_text(title).add_text(body));
+
+        if let Ok(_) = gs.add_node(notebook_ship, notebook_name, &node)
+        {
+            Ok(node.index.clone())
+        } 
+        else {
+            Err(UrbitAPIError::FailedToCreateNote(node.to_json().dump()))
+        }
+    }
+    
+    /// add a new comment to the notebook on note specified by `note_index`
+    /// `note_index` can be any valid note or comment index
+    pub fn add_comment(&mut self, notebook_ship: &str, notebook_name: &str, note_index: &str, comment: &NodeContents) -> Result<String> {
+        //check index
+        let index = NotebookIndex::new(note_index);
+        
+        if !index.is_valid() {
+            return Err(UrbitAPIError::InvalidNoteGraphNodeIndex(note_index.to_string()));
+        }
+
+        let mut gs = self.channel.graph_store();
+        let unix_time = get_current_time();
+
+        //make a new node under the note comments node  - this is root node for this comment
+        let cmt_root_node = gs.new_node_with_index(&index.new_comment_root_index(), unix_time, &NodeContents::new());
+        //update index helper from new node
+        let index = NotebookIndex::new(&cmt_root_node.index);
+        //make initial comment revision node
+        let cmt_rev_index = index.comment_revision_index(1)?;
+        let cmt_rev_node = gs.new_node_with_index(&cmt_rev_index, unix_time, comment);
+        //assemble node tree
+        let cmt_root_node = cmt_root_node.add_child(&cmt_rev_node);
+        //add the nodes
+        if let Ok(_) = gs.add_node(notebook_ship, notebook_name, &cmt_root_node)
+        {
+            Ok(cmt_rev_index.clone())
+        } else {
+            Err(UrbitAPIError::FailedToCreateComment(cmt_root_node.to_json().dump()))
+        }
+    }
+
+    /// update an existing comment on a note
+    /// comment_index should be any valid comment index, 
+    /// returns index of the new comment revision
+    pub fn update_comment(&mut self, notebook_ship: &str, notebook_name: &str, comment_index: &str, comment: &NodeContents) -> Result<String> {
+        
+        //fetch latest comment revision index (will return error if not a valid comment index)
+        let cmt_latest_index = self.fetch_comment_latest_revision_index(notebook_ship, notebook_name, comment_index)?;
+        //index helper
+        let index = NotebookIndex::new(&cmt_latest_index);
+        //build new node index
+        let cmt_new_index = index.next_revision_index()?;
+
+        // add the node
+        let mut gs = self.channel.graph_store();
+        let unix_time = get_current_time();
+
+        let node = gs.new_node_with_index(&cmt_new_index, unix_time, comment);
+
+        if let Ok(_) = gs.add_node(notebook_ship, notebook_name, &node)
+        {
+            Ok(node.index.clone())
+        } else {
+            Err(UrbitAPIError::FailedToCreateComment(node.to_json().dump()))
+        }        
+    }
+}
+
+impl<'a> NotebookIndex<'a> {
+    pub fn new(idx: &str) -> NotebookIndex {
+        NotebookIndex {
+            index: idx,
+            index_split: idx.split("/").collect()
+        }
+    }
+
+    //notebook index slices 
+    //must have at least 2 slices to be valid notebook index
+    //slice 0 must have len 0 - means index started with a "/" 
+    //slice 1 is note root node
+    //slice 2 is "1" for note, "2" for comment
+    //slice 3 is note revision or comment root node
+    //slice 4 is comment revision
+
+    /// is this any kind of valid notebook node index (comment or note)?
+    pub fn is_valid(&self) -> bool {
+        (self.index_split.len() >= 2) && (self.index_split[0].len() == 0)
+    }
+
+    /// is this the index of a note root node?
+    pub fn is_note_root(&self) -> bool {
+        (self.index_split.len() == 2) && (self.index_split[0].len() == 0)
+    }
+
+    /// is this the index of a specific note revision?
+    pub fn is_note_revision(&self) -> bool {
+        (self.index_split.len() == 4) && (self.index_split[0].len() == 0) && (self.index_split[2] == "1")
+    }
+
+    /// is this some kind of valid comment index?
+    pub fn is_valid_comment_index(&self) -> bool {
+        (self.index_split.len() >= 4) && (self.index_split[0].len() == 0) && (self.index_split[2] == "2")
+    }
+
+    /// is this the index of a comment root?
+    pub fn is_comment_root(&self) -> bool {
+        (self.index_split.len() == 4) && (self.index_split[0].len() == 0) && (self.index_split[2] == "2")
+    }
+
+    /// is this the index of a comment revision?
+    pub fn is_comment_revision(&self) -> bool {
+        (self.index_split.len() == 5) && (self.index_split[0].len() == 0) && (self.index_split[2] == "2")
+    }
+
+    /// root index of note
+    pub fn note_root_index(&self) -> String {
+        format!("/{}", self.index_split[1])
+    }
+
+    /// index of note content node, note revisions are children of this
+    pub fn note_content_node_index(&self) -> String {
+        format!("/{}/1", self.index_split[1])
+    }
+
+    /// index of note comments node, all note comments are children of this
+    pub fn note_comments_node_index(&self) -> String {
+        format!("/{}/2", self.index_split[1])
+    }
+
+    /// root index of comment (if this is a valid comment index)
+    /// all revisions of a comment are children of the comment root
+    pub fn comment_root_index(&self) -> Result<String> {
+        if self.is_valid_comment_index() {
+            Ok(format!("/{}/2/{}", self.index_split[1], self.index_split[3]))
+        } else {
+            Err(UrbitAPIError::InvalidCommentGraphNodeIndex(self.index.to_string()))
+        }
+    }
+    /// generate a new comment root index using `get_current_da_time()`
+    pub fn new_comment_root_index(&self) -> String {
+        format!("/{}/2/{}", self.index_split[1], get_current_da_time())
+    }
+
+    /// str slice of final element of index 
+    pub fn index_tail(&self) -> &str {
+        self.index_split[self.index_split.len() - 1]
+    }
+
+    /// revision number if this is index of a specific revision
+    pub fn revision(&self) -> Result<u64> {
+        if self.is_note_revision() {
+            if let Ok(r) = self.index_split[3].parse::<u64>() {
+                return Ok(r);
+            }
+        }
+        else if self.is_comment_revision() {
+            if let Ok(r) = self.index_split[4].parse::<u64>() {
+                return Ok(r);
+            }
+        }
+        
+        Err(UrbitAPIError::InvalidNoteGraphNodeIndex(self.index.to_string()))
+        
+    }
+
+    /// generates the index of next revision, if this is a valid note or comment revision index
+    pub fn next_revision_index(&self) -> Result<String> {
+        let rev = self.revision()?;
+        let newrev = rev + 1;
+        //we know index_split.len() is either 4 or 5 here as revision() was Ok
+        if self.index_split.len() == 5 {
+            Ok(format!("/{}/2/{}/{}", self.index_split[1], self.index_split[3], &newrev.to_string()))
+        }
+        else {
+            Ok(format!("/{}/1/{}", self.index_split[1], &newrev.to_string()))
+        }
+    }
+
+    /// generate a specific note revision index
+    pub fn note_revision_index(&self, revision: u64) -> String {
+        format!("/{}/1/{}", self.index_split[1], revision.to_string())
+    }
+
+    /// generate a specific comment revision index (if this is a valid comment index)
+    pub fn comment_revision_index(&self, revision: u64) -> Result<String> {
+        if self.is_valid_comment_index() {
+            Ok(format!("/{}/2/{}/{}", self.index_split[1], self.index_split[3], revision.to_string()))
+        } else {
+            Err(UrbitAPIError::InvalidCommentGraphNodeIndex(self.index.to_string()))
+        }
+    }
+
+    
 }

--- a/src/notebook.rs
+++ b/src/notebook.rs
@@ -332,17 +332,17 @@ impl<'a> Notebook<'a> {
         //make child 2 for comments
         //make child 1/1 for initial note revision
         let node_root = node_root
-            .add_child(&gs.new_node_with_index(
+            .add_child(&gs.new_node_specified(
                 &index.note_content_node_index(),
                 unix_time,
                 &NodeContents::new(),
             ))
-            .add_child(&gs.new_node_with_index(
+            .add_child(&gs.new_node_specified(
                 &index.note_comments_node_index(),
                 unix_time,
                 &NodeContents::new(),
             ))
-            .add_child(&gs.new_node_with_index(
+            .add_child(&gs.new_node_specified(
                 &index.note_revision_index(1),
                 unix_time,
                 &NodeContents::new().add_text(title).add_text(body),
@@ -380,7 +380,7 @@ impl<'a> Notebook<'a> {
         let unix_time = get_current_time();
 
         // add the node
-        let node = gs.new_node_with_index(
+        let node = gs.new_node_specified(
             &note_new_index,
             unix_time,
             &NodeContents::new().add_text(title).add_text(body),
@@ -413,7 +413,7 @@ impl<'a> Notebook<'a> {
         let unix_time = get_current_time();
 
         //make a new node under the note comments node  - this is root node for this comment
-        let cmt_root_node = gs.new_node_with_index(
+        let cmt_root_node = gs.new_node_specified(
             &index.new_comment_root_index(),
             unix_time,
             &NodeContents::new(),
@@ -422,7 +422,7 @@ impl<'a> Notebook<'a> {
         let index = NotebookIndex::new(&cmt_root_node.index);
         //make initial comment revision node
         let cmt_rev_index = index.comment_revision_index(1)?;
-        let cmt_rev_node = gs.new_node_with_index(&cmt_rev_index, unix_time, comment);
+        let cmt_rev_node = gs.new_node_specified(&cmt_rev_index, unix_time, comment);
         //assemble node tree
         let cmt_root_node = cmt_root_node.add_child(&cmt_rev_node);
         //add the nodes
@@ -457,7 +457,7 @@ impl<'a> Notebook<'a> {
         let mut gs = self.channel.graph_store();
         let unix_time = get_current_time();
 
-        let node = gs.new_node_with_index(&cmt_new_index, unix_time, comment);
+        let node = gs.new_node_specified(&cmt_new_index, unix_time, comment);
 
         if let Ok(_) = gs.add_node(notebook_ship, notebook_name, &node) {
             Ok(node.index.clone())


### PR DESCRIPTION
**Graph**
Replaced Node::from_graph_update_childless() with Node::from_graph_update() to handle children
Added Node::from_json()
Kept Node::from_json_childless as Graph::from_json() uses it

**GraphStore**
Added GraphStore::new_node_with_index() - needed to make child nodes
Added GraphStore::get_node() - does single node scry into Node struct

**Chat**
Added index field to AuthoredMessage
Updated chat subscribe worker to use Node::from_graph_update_json()

**Notebook**
Added index field to Note
Changed Note::contents to String as all note contents are in a single text item of markdown
Updated Note::from_node() to handle comment revisions, and now can select a specific note revision instead of latest if specified

Added methods to Notebook to fetch notes and comments, and find latest revision index for a note or comment
Added methods to Notebook to add and update notes and comments

Added NotebookIndex struct - helper for building and analysing notebook index paths

**Helper**
Added get_current_time() 
Added index_dec_to_ud() for transforming node index paths in node scry urls

**Error**
Added some note and comment errors